### PR TITLE
Allow custom formats when using formatMessage functions

### DIFF
--- a/lib/format-message.js
+++ b/lib/format-message.js
@@ -1,6 +1,7 @@
 /* global Intl:false */
 'use strict'
 
+var assign = require('lodash/object/assign')
 var MessageFormat = require('message-format')
 
 var formats = MessageFormat.data.formats
@@ -61,6 +62,11 @@ formatMessage.setup = function setup (opt) {
   if (opt.translate) currentTranslate = opt.translate
   if ('missingReplacement' in opt) missingReplacement = opt.missingReplacement
   if (opt.missingTranslation) missingTranslation = opt.missingTranslation
+  if (opt.customFormats) {
+    if (opt.customFormats.number) number = assign({}, number, opt.customFormats.number)
+    if (opt.customFormats.date) date = assign({}, date, opt.customFormats.date)
+    if (opt.customFormats.time) time = assign({}, time, opt.customFormats.time)
+  }
 }
 
 formatMessage.number = function (locale, value, style) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "commander": "^2.8.1",
     "format-message-core": "^3.1.0",
     "glob": "^5.0.2",
+    "lodash": "^3.10.1",
     "message-format": "^1.2.0"
   },
   "devDependencies": {

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -110,6 +110,15 @@ describe('formatMessage', function () {
 
       expect(message).to.equal('test-success')
     })
+
+    it('consumes custom formats', function () {
+      var customFormats = { number: { 'extended-usd': { style: 'currency', currency: 'usd', minimumFractionDigits: 2 } } }
+      formatMessage.setup({ customFormats: customFormats })
+
+      var message = formatMessage.number('en', 5600, 'extended-usd')
+
+      expect(message).to.equal('$5,600.00')
+    })
   })
 
   describe('translate', function () {


### PR DESCRIPTION
I am having trouble getting `npm run test-browsers` to run, as the `format-inline.specs.js` cannot find `require`, even on a clean master. For the most part, though, `lint` and `test-node` run without error.