### PR TITLE
fix #20 support custom formats, rework caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
-  - iojs
+  - "4.1"
+  - "stable"
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -67,7 +67,7 @@ module.exports = function (config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: [ 'Chrome', 'Firefox', 'Safari', 'PhantomJS' ],
+    browsers: [ 'Chrome', 'Firefox', 'Safari' ],
     browserNoActivityTimeout: 30000,
 
     // Continuous Integration mode

--- a/lib/format-message.js
+++ b/lib/format-message.js
@@ -1,6 +1,7 @@
 /* global Intl:false */
 'use strict'
 
+var assign = require('object-assign')
 var MessageFormat = require('message-format')
 
 var formats = MessageFormat.data.formats
@@ -15,22 +16,14 @@ var currentTranslate = function (pattern) { return pattern }
 var missingReplacement = null
 var missingTranslation = 'error'
 
-function cacheable (key, fn) {
-  if (!enableCache) return fn()
-  if (!(key in cache)) cache[key] = fn()
-  return cache[key]
-}
-
 module.exports = formatMessage
 function formatMessage (pattern, args, locale) {
   locale = locale || currentLocale
-  return cacheable(locale + ':format:' + pattern, function () {
-    return new MessageFormat(
-      translate(pattern, locale),
-      locale,
-      { cache: enableCache }
-    ).format
-  })(args)
+  var key = locale + ':format:' + pattern
+  var format = enableCache && cache[key] ||
+    new MessageFormat(translate(pattern, locale), locale).format
+  if (enableCache) cache[key] = format
+  return format(args)
 }
 
 function translate (originalPattern, locale) {
@@ -61,37 +54,42 @@ formatMessage.setup = function setup (opt) {
   if (opt.translate) currentTranslate = opt.translate
   if ('missingReplacement' in opt) missingReplacement = opt.missingReplacement
   if (opt.missingTranslation) missingTranslation = opt.missingTranslation
+  if (opt.formats) {
+    if (opt.formats.number) assign(number, opt.formats.number)
+    if (opt.formats.date) assign(date, opt.formats.date)
+    if (opt.formats.time) assign(time, opt.formats.time)
+  }
 }
 
 formatMessage.number = function (locale, value, style) {
-  style = style || 'medium'
-  return cacheable(locale + ':number:' + style, function () {
-    return (typeof Intl !== 'undefined' && Intl.NumberFormat)
-      ? new Intl.NumberFormat(locale, number[style]).format
-      : function (arg) {
-        return Number(arg).toLocaleString(locale, number[style])
-      }
-  })(value)
+  var options = number[style] || number.medium
+  if (!enableCache || typeof Intl === 'undefined') {
+    return Number(value).toLocaleString(locale, options)
+  }
+  var key = locale + ':number:' + (number[style] ? style : 'medium')
+  var format = cache[key] ||
+    (cache[key] = new Intl.NumberFormat(locale, options).format)
+  return format(value)
 }
 
 formatMessage.date = function (locale, value, style) {
-  style = style || 'medium'
-  return cacheable(locale + ':date:' + style, function () {
-    return (typeof Intl !== 'undefined' && Intl.DateTimeFormat)
-      ? new Intl.DateTimeFormat(locale, date[style]).format
-      : function (arg) {
-        return new Date(arg).toLocaleDateString(locale, date[style])
-      }
-  })(value)
+  var options = date[style] || date.medium
+  if (!enableCache || typeof Intl === 'undefined') {
+    return new Date(value).toLocaleDateString(locale, options)
+  }
+  var key = locale + ':date:' + (date[style] ? style : 'medium')
+  var format = cache[key] ||
+    (cache[key] = new Intl.DateTimeFormat(locale, options).format)
+  return format(value)
 }
 
 formatMessage.time = function (locale, value, style) {
-  style = style || 'medium'
-  return cacheable(locale + ':time:' + style, function () {
-    return (typeof Intl !== 'undefined' && Intl.DateTimeFormat)
-      ? new Intl.DateTimeFormat(locale, time[style]).format
-      : function (arg) {
-        return new Date(arg).toLocaleTimeString(locale, time[style])
-      }
-  })(value)
+  var options = time[style] || time.medium
+  if (!enableCache || typeof Intl === 'undefined') {
+    return new Date(value).toLocaleTimeString(locale, options)
+  }
+  var key = locale + ':time:' + (time[style] ? style : 'medium')
+  var format = cache[key] ||
+    (cache[key] = new Intl.DateTimeFormat(locale, options).format)
+  return format(value)
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "commander": "^2.8.1",
     "format-message-core": "^3.1.0",
     "glob": "^5.0.2",
-    "message-format": "^1.2.0"
+    "message-format": "^1.2.0",
+    "object-assign": "^4.0.1"
   },
   "devDependencies": {
     "benchmark": "^1.0.0",
@@ -39,12 +40,10 @@
     "karma-cli": "^0.1.0",
     "karma-firefox-launcher": "^0.1.4",
     "karma-mocha": "^0.2.0",
-    "karma-phantomjs-launcher": "^0.2.0",
     "karma-safari-launcher": "^0.1.1",
     "karma-sourcemap-loader": "^0.3.4",
     "karma-webpack": "^1.5.1",
     "mocha": "^2.2.5",
-    "phantomjs": "^1.9.18",
     "standard": "^5.0.0",
     "webpack": "^1.9.10"
   },
@@ -54,7 +53,7 @@
     "lint": "standard",
     "prepublish": "webpack -p",
     "test": "npm run lint && npm run test-setup && npm run test-node && npm run test-browsers",
-    "test-browsers": "karma start --browsers Firefox,PhantomJS --single-run",
+    "test-browsers": "karma start --browsers Firefox --single-run",
     "test-setup": "rm -rf test/inline && bin/format-message inline test/format.spec.js > test/format-inline.spec.js",
     "test-node": "istanbul cover _mocha -- -cG --timeout 10000 -R dot test/**/*.spec.js"
   },

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -113,6 +113,27 @@ describe('formatMessage', function () {
 
       expect(message).to.equal('test-success')
     })
+
+    it('adds custom formats', function () {
+      formatMessage.setup({ formats: {
+        number: { perc: {
+          style: 'percent',
+          maximumSignificantDigits: 1
+        } },
+        date: { day: {
+          day: '2-digit'
+        } },
+        time: { minute: {
+          minute: 'numeric'
+        } }
+      } })
+      var message = formatMessage('{ n, number, perc }', { n: 0.3672 })
+      expect(message).to.equal('40%')
+      message = formatMessage('{ d, date, day }', { d: new Date('2015/10/19') })
+      expect(message).to.equal('19')
+      message = formatMessage('{ t, time, minute }', { t: new Date('2015/10/19 5:06') })
+      expect(message).to.equal('6')
+    })
   })
 
   describe('translate', function () {


### PR DESCRIPTION
* Accept `formats` option in `setup` that adds any defined formats to the available formats.
* If style isn't defined, make sure medium style options are used instead of `null`.
* Rework caching to only use Intl.*Format objects when caching is enabled.
* Dump PhantomJS, since it isn't much like modern browsers, and causes hard-to-test inconsistencies in date and time formatting.