### PR TITLE
allow creating namespaced formatMessage functions

### DIFF
--- a/packages/format-message-estree-util/index.js
+++ b/packages/format-message-estree-util/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+var MODULE_NAME_PATTERN = /(^|\/)format-message$/
+
 exports = module.exports = {
   setBabelContext: function (path, state) {
     this.context = {
@@ -72,7 +74,7 @@ exports = module.exports = {
     return (
       parent && parent.source &&
       this.isStringLiteral(parent.source) &&
-      parent.source.value === 'format-message' && (
+      MODULE_NAME_PATTERN.test(parent.source.value) && (
         node.type === 'ImportDefaultSpecifier' ||
         node.type === 'ImportSpecifier' &&
         node.imported && node.imported.name === 'default'
@@ -88,7 +90,7 @@ exports = module.exports = {
       node.callee.name === 'require' &&
       !!(arg = node.arguments[0]) &&
       this.isStringLiteral(arg) &&
-      arg.value === 'format-message'
+      MODULE_NAME_PATTERN.test(arg.value)
     )
   },
 
@@ -230,7 +232,7 @@ exports = module.exports = {
         this.isHelperName(name)
       ) &&
       this.isStringLiteral(parent.source) &&
-      parent.source.value === 'format-message'
+      MODULE_NAME_PATTERN.test(parent.source.value)
     )
     if (isImportHelper) return name
   },

--- a/packages/format-message/README.md
+++ b/packages/format-message/README.md
@@ -120,6 +120,42 @@ Parameters
     - `date` is an object containing date format styles to add. Each property name can be used afterwards as a style name for a date placeholder. The value of each property is an object that will be passed to an [`Intl.DateTimeFormat`][mdn-intl-datetimeformat] constructor as the second argument.
     - `time` is an object containing time format styles to add. Each property name can be used afterwards as a style name for a time placeholder. The value of each property is an object that will be passed to an [`Intl.DateTimeFormat`][mdn-intl-datetimeformat] constructor as the second argument.
 
+### `formatMessage.namespace()`
+
+Return a new instance of `formatMessage` with isolated configuration. Calls to `setup()`
+on the new namespace will not be affect any another namespace (including the global
+namespace).
+
+```js
+var namespace = formatMessage.namespace()
+
+formatMessage.setup({
+  locale: "en",
+  translations: {
+    en: {
+      foo: "foo"
+    }
+  }
+})
+
+namespace.setup({
+  locale: "fr",
+  transations: {
+    fr: {
+      foo: "bar"
+    }
+  }
+})
+
+formatMessage("foo") // => "foo"
+namespace("foo") // => "bar"
+```
+
+If you are using a custom namespace and still want to be able to extract strings
+using the format message CLI, create a module named `format-message.js` that exports
+the new namespace. Import formatMessage from this module in all other modules that
+use the namespace.
+
 ### Localization apis
 
 format-message also provides a few extra functions to simplify localizing (but not translating) data. These mostly just pass through to `Intl` APIs.

--- a/packages/format-message/index.js
+++ b/packages/format-message/index.js
@@ -8,114 +8,121 @@ var plurals = require('format-message-interpret/plurals')
 var lookupClosestLocale = require('lookup-closest-locale')
 var formats = require('format-message-formats')
 
-var cache = {}
+function namespace () {
+  var cache = {}
 
-var currentLocale = 'en'
-var translations = null
-var generateId = function (pattern) { return pattern }
-var missingReplacement = null
-var missingTranslation = 'warning'
+  var nsFormats = assign({}, formats)
+  var currentLocale = 'en'
+  var translations = null
+  var generateId = function (pattern) { return pattern }
+  var missingReplacement = null
+  var missingTranslation = 'warning'
 
-module.exports = exports = formatMessage
-function formatMessage (msg, args, locale) {
-  locale = locale || currentLocale
-  var pattern = typeof msg === 'string' ? msg : msg.default
-  var id = typeof msg === 'object' && msg.id || generateId(pattern)
-  var key = locale + ':' + id
-  var format = cache[key] ||
-    (cache[key] = generateFormat(pattern, id, locale))
-  if (typeof format === 'string') return format
-  return format(args)
-}
-
-function generateFormat (pattern, id, locale) {
-  pattern = translate(pattern, id, locale)
-  return interpret(locale, parse(pattern))
-}
-
-function translate (pattern, id, locale) {
-  if (!translations) return pattern
-
-  locale = lookupClosestLocale(locale, translations)
-  var translated = translations[locale] && translations[locale][id]
-  if (translated && translated.message) translated = translated.message
-  if (translated != null) return translated
-
-  var replacement = missingReplacement || pattern
-  if (typeof replacement === 'function') {
-    replacement = replacement(pattern, id, locale) || pattern
-  }
-  var message = 'Translation for "' + id + '" in "' + locale + '" is missing'
-
-  if (missingTranslation === 'ignore') {
-    // do nothing
-  } else if (missingTranslation === 'warning') {
-    if (typeof console !== 'undefined') console.warn(message)
-  } else { // 'error'
-    throw new Error(message)
+  function formatMessage (msg, args, locale) {
+    locale = locale || currentLocale
+    var pattern = typeof msg === 'string' ? msg : msg.default
+    var id = typeof msg === 'object' && msg.id || generateId(pattern)
+    var key = locale + ':' + id
+    var format = cache[key] ||
+      (cache[key] = generateFormat(pattern, id, locale))
+    if (typeof format === 'string') return format
+    return format(args)
   }
 
-  return replacement
-}
-
-exports.setup = function setup (opt) {
-  opt = opt || {}
-  if (opt.locale) currentLocale = opt.locale
-  if ('translations' in opt) translations = opt.translations
-  if (opt.generateId) generateId = opt.generateId
-  if ('missingReplacement' in opt) missingReplacement = opt.missingReplacement
-  if (opt.missingTranslation) missingTranslation = opt.missingTranslation
-  if (opt.formats) {
-    if (opt.formats.number) assign(formats.number, opt.formats.number)
-    if (opt.formats.date) assign(formats.date, opt.formats.date)
-    if (opt.formats.time) assign(formats.time, opt.formats.time)
-  }
-  return {
-    locale: currentLocale,
-    translations: translations,
-    generateId: generateId,
-    missingReplacement: missingReplacement,
-    missingTranslation: missingTranslation,
-    formats: formats
-  }
-}
-
-function helper (type, value, style, locale) {
-  locale = locale || currentLocale
-  var options = formats[type][style] || formats[type].default
-  var cache = options.cache || (options.cache = {})
-  var format = cache[locale] || (cache[locale] = type === 'number'
-    ? Intl.NumberFormat(locale, options).format
-    : Intl.DateTimeFormat(locale, options).format
-  )
-  return format(value)
-}
-
-exports.number = helper.bind(null, 'number')
-exports.date = helper.bind(null, 'date')
-exports.time = helper.bind(null, 'time')
-
-exports.select = function (value, options) {
-  return options[value] || options.other
-}
-
-function selectPlural (pluralType, value, offset, options, locale) {
-  if (typeof offset === 'object') { // offset is optional
-    locale = options
-    options = offset
-    offset = 0
+  function generateFormat (pattern, id, locale) {
+    pattern = translate(pattern, id, locale)
+    return interpret(locale, parse(pattern))
   }
 
-  var closest = lookupClosestLocale(locale || currentLocale, plurals)
-  var plural = plurals[closest][pluralType]
-  if (!plural) return options.other
+  function translate (pattern, id, locale) {
+    if (!translations) return pattern
 
-  return (
-    options['=' + +value] ||
-    options[plural(value - offset)] ||
-    options.other
-  )
+    locale = lookupClosestLocale(locale, translations)
+    var translated = translations[locale] && translations[locale][id]
+    if (translated && translated.message) translated = translated.message
+    if (translated != null) return translated
+
+    var replacement = missingReplacement || pattern
+    if (typeof replacement === 'function') {
+      replacement = replacement(pattern, id, locale) || pattern
+    }
+    var message = 'Translation for "' + id + '" in "' + locale + '" is missing'
+
+    if (missingTranslation === 'ignore') {
+      // do nothing
+    } else if (missingTranslation === 'warning') {
+      if (typeof console !== 'undefined') console.warn(message)
+    } else { // 'error'
+      throw new Error(message)
+    }
+
+    return replacement
+  }
+
+  formatMessage.setup = function setup (opt) {
+    opt = opt || {}
+    if (opt.locale) currentLocale = opt.locale
+    if ('translations' in opt) translations = opt.translations
+    if (opt.generateId) generateId = opt.generateId
+    if ('missingReplacement' in opt) missingReplacement = opt.missingReplacement
+    if (opt.missingTranslation) missingTranslation = opt.missingTranslation
+    if (opt.formats) {
+      if (opt.formats.number) assign(nsFormats.number, opt.formats.number)
+      if (opt.formats.date) assign(nsFormats.date, opt.formats.date)
+      if (opt.formats.time) assign(nsFormats.time, opt.formats.time)
+    }
+    return {
+      locale: currentLocale,
+      translations: translations,
+      generateId: generateId,
+      missingReplacement: missingReplacement,
+      missingTranslation: missingTranslation,
+      formats: nsFormats
+    }
+  }
+
+  function helper (type, value, style, locale) {
+    locale = locale || currentLocale
+    var options = nsFormats[type][style] || nsFormats[type].default
+    var cache = options.cache || (options.cache = {})
+    var format = cache[locale] || (cache[locale] = type === 'number'
+      ? Intl.NumberFormat(locale, options).format
+      : Intl.DateTimeFormat(locale, options).format
+    )
+    return format(value)
+  }
+
+  formatMessage.number = helper.bind(null, 'number')
+  formatMessage.date = helper.bind(null, 'date')
+  formatMessage.time = helper.bind(null, 'time')
+
+  formatMessage.select = function (value, options) {
+    return options[value] || options.other
+  }
+
+  function selectPlural (pluralType, value, offset, options, locale) {
+    if (typeof offset === 'object') { // offset is optional
+      locale = options
+      options = offset
+      offset = 0
+    }
+
+    var closest = lookupClosestLocale(locale || currentLocale, plurals)
+    var plural = plurals[closest][pluralType]
+    if (!plural) return options.other
+
+    return (
+      options['=' + +value] ||
+      options[plural(value - offset)] ||
+      options.other
+    )
+  }
+
+  formatMessage.plural = selectPlural.bind(null, 'cardinal')
+  formatMessage.selectordinal = selectPlural.bind(null, 'ordinal')
+
+  return formatMessage
 }
 
-exports.plural = selectPlural.bind(null, 'cardinal')
-exports.selectordinal = selectPlural.bind(null, 'ordinal')
+module.exports = exports = namespace()
+exports.namespace = namespace

--- a/test/extract.cli.spec.js
+++ b/test/extract.cli.spec.js
@@ -250,6 +250,34 @@ describe('format-message extract', function () {
         done(err)
       }).stdin.end(input, 'utf8')
     })
+
+    describe('with custom modules named format-message', function () {
+      it('finds function name from require call', function (done) {
+        var input = 'var f=require("./custom/format-message");f("hello")'
+        exec('packages/format-message-cli/format-message extract', function (err, stdout, stderr) {
+          stdout = stdout.toString('utf8')
+          var translations = JSON.parse(stdout)
+          expect(translations).to.eql({
+            hello_32e420db: { message: 'hello' }
+          })
+          expect(stderr.toString('utf8')).to.equal('')
+          done(err)
+        }).stdin.end(input, 'utf8')
+      })
+
+      it('finds function name from import', function (done) {
+        var input = 'import __ from "./custom/format-message";__("hello")'
+        exec('packages/format-message-cli/format-message extract', function (err, stdout, stderr) {
+          stdout = stdout.toString('utf8')
+          var translations = JSON.parse(stdout)
+          expect(translations).to.eql({
+            hello_32e420db: { message: 'hello' }
+          })
+          expect(stderr.toString('utf8')).to.equal('')
+          done(err)
+        }).stdin.end(input, 'utf8')
+      })
+    })
   })
 
   describe('translate="yes"', function () {

--- a/test/format.spec.js
+++ b/test/format.spec.js
@@ -344,4 +344,29 @@ describe('formatMessage', function () {
       expect(result).to.equal(1)
     })
   })
+
+  describe('namespace', function () {
+    var ns, options
+
+    beforeEach(function () {
+      ns = formatMessage.namespace()
+      options = ns.setup({
+        locale: 'fr',
+        translations: {
+          fr: {
+            foo: 'bar'
+          }
+        }
+      })
+    })
+
+    it('setup does not change other namespaces', function () {
+      var globalOptions = formatMessage.setup()
+      expect(options.transations).not.to.equal(globalOptions.translations)
+    })
+
+    it('uses its own configuration', function () {
+      expect(ns('foo')).to.equal('bar')
+    })
+  })
 })


### PR DESCRIPTION
format message configuration is currently uses global values. this
works for most use cases, but there are some cases where it makes
sense to to allow multiple configurations in the same project. this
is especially usefult for libraries that want to use format message
to localize strings without conflicting with other code using format
message.

calling formatMessage.namespace() will return an isolated instance
of formatMessage. calling setup on this instance will not affect any
other instances of format message. the typical use case would be to
have a module that exports the namespaced instance of formatMessage.

importing formatMessage from a different module would break the
static analysis that is used for extracting messages. it now works
with any module named `format-message` even if it is not in
node_modules.