### PR TITLE
Allow tag names in addition to numeric indexes

### DIFF
--- a/packages/format-message/README.md
+++ b/packages/format-message/README.md
@@ -279,6 +279,7 @@ export default ({ extensions }) =>
     )}
   </div>
 ```
+To be valid, a tag name can include any character except `<`, `/`, `>`, and whitespace characters.
 
 
 ### format-message/inferno

--- a/packages/format-message/README.md
+++ b/packages/format-message/README.md
@@ -260,6 +260,27 @@ produces the same tree as
 </div>
 ```
 
+You can also provide an Object and use tag names that match the object's property names
+
+```jsx
+import formatMessage from 'format-message'
+import {formatChildren} from 'format-message/react'
+
+export default ({ extensions }) =>
+  <div title={formatMessage('Choose a file')}>
+    {formatChildren(
+      formatMessage('Drag & Drop {extensions} files here <span1>or</span1> <span2>Browse</span2>', {
+        extensions
+      }),
+      {
+        span1: <span className="or" />,
+        span2: <span className="browse" />
+      }
+    )}
+  </div>
+```
+
+
 ### format-message/inferno
 
 This module includes utilities for working specifically with Inferno when composing messages with embedded components. The API is identical to format-message/react, only it works with Inferno vdom nodes instead of React elements.

--- a/packages/format-message/base-format-children.js
+++ b/packages/format-message/base-format-children.js
@@ -6,7 +6,7 @@
  * collects children for that wrapper until the ending token is found.
  */
 module.exports = function formatChildren (applyChildren, message, wrappers) {
-  var validChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$'
+  var invalidChars = '</> \n\t\r'
 
   if (!wrappers) return message
   var mm = message.length
@@ -30,11 +30,11 @@ module.exports = function formatChildren (applyChildren, message, wrappers) {
     }
 
     var e = s
-    while (validChars.indexOf(message[e]) >= 0) { ++e }
+    while (invalidChars.indexOf(message[e]) < 0) { ++e }
     if (!isEnd && message.slice(e, e + 2) === '/>') {
       isSelfClosing = true
     } else if (message[e] !== '>') {
-      continue
+      throw new Error('Wrapping tags include invalid characters in "' + message + '". Valid characters are any character except `<`, `/`, `>`, and whitespace characters.')
     }
 
     var key = message.slice(s, e)

--- a/packages/format-message/base-format-children.js
+++ b/packages/format-message/base-format-children.js
@@ -6,6 +6,8 @@
  * collects children for that wrapper until the ending token is found.
  */
 module.exports = function formatChildren (applyChildren, message, wrappers) {
+  var validChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_$'
+
   if (!wrappers) return message
   var mm = message.length
   var stack = []
@@ -28,14 +30,14 @@ module.exports = function formatChildren (applyChildren, message, wrappers) {
     }
 
     var e = s
-    while (message[e] >= '0' && message[e] <= '9') { ++e }
+    while (validChars.indexOf(message[e]) >= 0) { ++e }
     if (!isEnd && message.slice(e, e + 2) === '/>') {
       isSelfClosing = true
     } else if (message[e] !== '>') {
       continue
     }
 
-    var key = +message.slice(s, e)
+    var key = message.slice(s, e)
     if (!wrappers[key]) continue
     ++e
     if (isSelfClosing) ++e

--- a/test/inferno.spec.js
+++ b/test/inferno.spec.js
@@ -3,7 +3,7 @@ var expect = require('chai').expect
 var createElement = require('inferno-create-element')
 var formatChildren = require('../packages/format-message/inferno').formatChildren
 
-describe('inferno formatChildren', function () {
+describe('inferno formatChildren with numeric index tags', function () {
   it('returns a single child for simple messages', function () {
     var results = formatChildren('simple')
     expect(results).to.equal('simple')
@@ -79,6 +79,81 @@ describe('inferno formatChildren', function () {
     }).to.throw()
     expect(function () {
       formatChildren('<0>test</0>', [ 1 ])
+    }).to.throw()
+  })
+})
+
+describe('inferno formatChildren with string tags', function () {
+  it('preserves tokens with no element mapping', function () {
+    var results = formatChildren('<span>simple</span>')
+    expect(results).to.equal('<span>simple</span>')
+  })
+
+  it('returns a single child for wrapped messages', function () {
+    var results = formatChildren('<span>simple</span>', {
+      span: createElement('span')
+    })
+    expect(results).to.deep.equal(createElement('span', null, 'simple'))
+  })
+
+  it('preserves the props of the wrappers', function () {
+    var results = formatChildren('<span>simple</span>', {
+      span: createElement('span', { className: 'foo' })
+    })
+    expect(results).to.deep.equal(createElement('span', {
+      className: 'foo'
+    }, 'simple'))
+  })
+
+  it('returns an array of children when there are many', function () {
+    var results = formatChildren('it was <em>his</em> fault', {
+      em: createElement('em')
+    })
+    expect(results).to.deep.equal([
+      'it was ',
+      createElement('em', null, 'his'),
+      ' fault'
+    ])
+  })
+
+  it('nests arbitrarily deep', function () {
+    var results = formatChildren('<div><span><em><strong>deep</strong></em></span></div>', {
+      div: createElement('div'),
+      span: createElement('span'),
+      em: createElement('em'),
+      strong: createElement('strong')
+    })
+    expect(results).to.deep.equal(
+      createElement('div', null,
+        createElement('span', null,
+          createElement('em', null,
+            createElement('strong', null, 'deep')
+          )
+        )
+      )
+    )
+  })
+
+  it('throws when wrapper tokens aren\'t nested properly', function () {
+    expect(function () {
+      formatChildren('<div><em><span><strong>deep</span></strong></em></div>', {
+        div: createElement('div'),
+        em: createElement('em'),
+        span: createElement('span'),
+        strong: createElement('strong')
+      })
+    }).to.throw()
+  })
+
+  it('throws when mappings aren\'t valid elements', function () {
+    expect(function () {
+      formatChildren('<span>test</span>', { span: 'span' })
+    }).to.throw()
+    expect(function () {
+      formatChildren('<foo>test</foo>', { foo: {} })
+    }).to.throw()
+    expect(function () {
+      formatChildren('<foo>test</foo>', { foo: 1 })
     }).to.throw()
   })
 })

--- a/test/react.spec.js
+++ b/test/react.spec.js
@@ -156,4 +156,19 @@ describe('react formatChildren with string tags', function () {
       formatChildren('<foo>test</foo>', { foo: 1 })
     }).to.throw()
   })
+
+  it('throws when wrapper tag names aren\'t valid', function () {
+    expect(function () {
+      formatChildren('<sp an>test</sp an>', { span: 'span' })
+    }).to.throw()
+    expect(function () {
+      formatChildren('<sp\nan>test</sp\nan>', { span: 'span' })
+    }).to.throw()
+    expect(function () {
+      formatChildren('<sp/an>test</sp/an>', { span: 'span' })
+    }).to.throw()
+    expect(function () {
+      formatChildren('<sp<an>test</sp<an>', { span: 'span' })
+    }).to.throw()
+  })
 })


### PR DESCRIPTION
Allow tags in `formatChildren()` messages to have names that are strings.

`formatChildren()` can now accept an Object or Array as the second argument. When it's matching tags to components to substitute, it looks for a key on the `elements` parameter with the matching name. If `elements` is an Array, the integer indexes in the tags function as keys. If `elements` is an object, the tag names are used to find matching properties in the object.

This makes it possible to use names for tags. to provide more context to translators and also to developers. For example:

```jsx
// (React)
formatChildren(formatMessage('I have something <em>important</em> to show you. <a>View</a>'), {
  em: <em className="prominent"/>,
  a: <a href="path-to-url"/>
})
```

The tag names may only include characters that are valid in property names (i.e. only upper- and lowercase letters, numbers, underscore, and dollar sign).