### PR TITLE
Fix 'unique "key" prop' error with react `formatChildren()`

### DIFF
--- a/packages/format-message/react.js
+++ b/packages/format-message/react.js
@@ -3,11 +3,18 @@
 var React = require('react')
 var formatChildren = require('./base-format-children')
 
+var __counter__ = 0
+
+function makeKey (element) {
+  return element.type + '::' + (__counter__++).toString(16)
+}
+
 function applyChildren (element, children) {
   if (process.env.NODE_ENV !== 'production' && !React.isValidElement(element)) {
     throw new Error(JSON.stringify(element) + ' is not a valid element')
   }
-  return React.cloneElement.apply(React, [ element, null ].concat(children || []))
+  var key = element.key || makeKey(element)
+  return React.cloneElement.apply(React, [ element, { key: key } ].concat(children || []))
 }
 
 exports.formatChildren = formatChildren.bind(null, applyChildren)

--- a/test/react.spec.js
+++ b/test/react.spec.js
@@ -16,43 +16,54 @@ describe('react formatChildren', function () {
 
   it('returns a single child for wrapped messages', function () {
     var results = formatChildren('<0>simple</0>', [
-      React.createElement('span')
+      React.createElement('span', { key: '0' })
     ])
-    expect(results).to.deep.equal(React.createElement('span', null, 'simple'))
+    expect(results).to.deep.equal(React.createElement('span', { key: '0' }, 'simple'))
   })
 
   it('preserves the props of the wrappers', function () {
     var results = formatChildren('<0>simple</0>', [
+      React.createElement('span', { className: 'foo', key: '0' })
+    ])
+    expect(results).to.deep.equal(React.createElement('span', {
+      className: 'foo',
+      key: '0'
+    }, 'simple'))
+  })
+
+  it('creates a `key` prop if it is not defined', function () {
+    var results = formatChildren('<0>simple</0>', [
       React.createElement('span', { className: 'foo' })
     ])
     expect(results).to.deep.equal(React.createElement('span', {
-      className: 'foo'
+      className: 'foo',
+      key: 'span::0'
     }, 'simple'))
   })
 
   it('returns an array of children when there are many', function () {
     var results = formatChildren('it was <0>his</0> fault', [
-      React.createElement('em')
+      React.createElement('em', { key: '0' })
     ])
     expect(results).to.deep.equal([
       'it was ',
-      React.createElement('em', null, 'his'),
+      React.createElement('em', { key: '0' }, 'his'),
       ' fault'
     ])
   })
 
   it('nests arbitrarily deep', function () {
     var results = formatChildren('<0><1><2><3>deep</3></2></1></0>', [
-      React.createElement('div'),
-      React.createElement('span'),
-      React.createElement('em'),
-      React.createElement('strong')
+      React.createElement('div', { key: '0' }),
+      React.createElement('span', { key: '1' }),
+      React.createElement('em', { key: '2' }),
+      React.createElement('strong', { key: '3' })
     ])
     expect(results).to.deep.equal(
-      React.createElement('div', null,
-        React.createElement('span', null,
-          React.createElement('em', null,
-            React.createElement('strong', null, 'deep')
+      React.createElement('div', { key: '0' },
+        React.createElement('span', { key: '1' },
+          React.createElement('em', { key: '2' },
+            React.createElement('strong', { key: '3' }, 'deep')
           )
         )
       )
@@ -62,10 +73,10 @@ describe('react formatChildren', function () {
   it('throws when wrapper tokens aren\'t nested properly', function () {
     expect(function () {
       formatChildren('<0><1><2><3>deep</2></3></1></0>', [
-        React.createElement('div'),
-        React.createElement('em'),
-        React.createElement('span'),
-        React.createElement('strong')
+        React.createElement('div', { key: '0' }),
+        React.createElement('span', { key: '1' }),
+        React.createElement('em', { key: '2' }),
+        React.createElement('strong', { key: '3' })
       ])
     }).to.throw()
   })


### PR DESCRIPTION
Using the React form of `formatChildren()`, the following message appears in the browser console for each React component that's passed to `formatChildren()` that doesn't include a `key` property:

```
Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `Component1Indexed`. See https://fb.me/react-warning-keys for more information.
```

This change fixes the problem by dynamically creating a unique key if the `key` property isn't already defined. The key is created as a combination of the element type and a "global" incrementing counter (so multiple elements of the same type don't have duplicate ids).

---------------------------
As a side note, this change will cause some failures in the tests that were added in #117. If both are considered acceptable, I can fix those tests so that they will be compatible with this change.