### PR TITLE
fix(formatChildren): fix react unique key warning

### DIFF
--- a/packages/babel-plugin-transform-format-message/inline-message-jsx.js
+++ b/packages/babel-plugin-transform-format-message/inline-message-jsx.js
@@ -5,7 +5,7 @@ var parse = require('format-message-parse')
 var formats = require('format-message-formats')
 var addHelper = require('./inline-helpers').addHelper
 
-var formatChildren = baseFormatChildren.bind(null, function (element, children) {
+var formatChildren = baseFormatChildren.bind(null, function (key, element, children) {
   if (!children) return '{ ' + element + ' }'
   return '{ ' + element + ', select, other {' + children.join('') + '} }'
 })

--- a/packages/eslint-plugin-format-message/lib/rules/no-invalid-translation.js
+++ b/packages/eslint-plugin-format-message/lib/rules/no-invalid-translation.js
@@ -4,7 +4,7 @@ var baseFormatChildren = require('format-message/base-format-children')
 var parse = require('format-message-parse')
 var visitEachTranslation = require('../util/visit-each-translation')
 
-var formatChildren = baseFormatChildren.bind(null, function (element, children) {
+var formatChildren = baseFormatChildren.bind(null, function (key, element, children) {
   if (!children) return '{ ' + element + ' }'
   return '{ ' + element + ', select, other {' + children.join('') + '} }'
 })

--- a/packages/format-message/base-format-children.js
+++ b/packages/format-message/base-format-children.js
@@ -47,7 +47,7 @@ module.exports = function formatChildren (applyChildren, message, wrappers) {
     }
 
     if (isSelfClosing) {
-      current.push(applyChildren(wrappers[key], null))
+      current.push(applyChildren(key, wrappers[key], null))
     } else if (isEnd) {
       if (currentKey !== key) {
         throw new Error('Wrapping tags not properly nested in "' + message + '"')
@@ -55,7 +55,7 @@ module.exports = function formatChildren (applyChildren, message, wrappers) {
       var children = current
       current = stack.pop()
       currentKey = stack.pop()
-      current.push(applyChildren(wrappers[key], children))
+      current.push(applyChildren(key, wrappers[key], children))
     } else { // start token
       stack.push(currentKey)
       stack.push(current)

--- a/packages/format-message/inferno.js
+++ b/packages/format-message/inferno.js
@@ -2,7 +2,7 @@
 
 var formatChildren = require('./base-format-children')
 
-function applyChildren (element, children) {
+function applyChildren (key, element, children) {
   if (process.env.NODE_ENV !== 'production' && !element.flags) {
     throw new Error(JSON.stringify(element) + ' is not a valid element')
   }

--- a/packages/format-message/react.js
+++ b/packages/format-message/react.js
@@ -3,11 +3,14 @@
 var React = require('react')
 var formatChildren = require('./base-format-children')
 
-function applyChildren (element, children) {
+function applyChildren (key, element, children) {
   if (process.env.NODE_ENV !== 'production' && !React.isValidElement(element)) {
     throw new Error(JSON.stringify(element) + ' is not a valid element')
   }
-  return React.cloneElement.apply(React, [ element, null ].concat(children || []))
+  return React.cloneElement.apply(
+    React,
+    [ element, { key: element.key || key } ].concat(children || [])
+  )
 }
 
 exports.formatChildren = formatChildren.bind(null, applyChildren)

--- a/test/react.spec.js
+++ b/test/react.spec.js
@@ -18,7 +18,7 @@ describe('react formatChildren with numeric index tags', function () {
     var results = formatChildren('<0>simple</0>', [
       React.createElement('span')
     ])
-    expect(results).to.deep.equal(React.createElement('span', null, 'simple'))
+    expect(results).to.deep.equal(React.createElement('span', { key: '0' }, 'simple'))
   })
 
   it('preserves the props of the wrappers', function () {
@@ -26,7 +26,8 @@ describe('react formatChildren with numeric index tags', function () {
       React.createElement('span', { className: 'foo' })
     ])
     expect(results).to.deep.equal(React.createElement('span', {
-      className: 'foo'
+      className: 'foo',
+      key: '0'
     }, 'simple'))
   })
 
@@ -36,7 +37,7 @@ describe('react formatChildren with numeric index tags', function () {
     ])
     expect(results).to.deep.equal([
       'it was ',
-      React.createElement('em', null, 'his'),
+      React.createElement('em', { key: '0' }, 'his'),
       ' fault'
     ])
   })
@@ -49,10 +50,10 @@ describe('react formatChildren with numeric index tags', function () {
       React.createElement('strong')
     ])
     expect(results).to.deep.equal(
-      React.createElement('div', null,
-        React.createElement('span', null,
-          React.createElement('em', null,
-            React.createElement('strong', null, 'deep')
+      React.createElement('div', { key: '0' },
+        React.createElement('span', { key: '1' },
+          React.createElement('em', { key: '2' },
+            React.createElement('strong', { key: '3' }, 'deep')
           )
         )
       )
@@ -93,7 +94,7 @@ describe('react formatChildren with string tags', function () {
     var results = formatChildren('<span>simple</span>', {
       span: React.createElement('span')
     })
-    expect(results).to.deep.equal(React.createElement('span', null, 'simple'))
+    expect(results).to.deep.equal(React.createElement('span', { key: 'span' }, 'simple'))
   })
 
   it('preserves the props of the wrappers', function () {
@@ -101,7 +102,8 @@ describe('react formatChildren with string tags', function () {
       span: React.createElement('span', { className: 'foo' })
     })
     expect(results).to.deep.equal(React.createElement('span', {
-      className: 'foo'
+      className: 'foo',
+      key: 'span'
     }, 'simple'))
   })
 
@@ -111,7 +113,7 @@ describe('react formatChildren with string tags', function () {
     })
     expect(results).to.deep.equal([
       'it was ',
-      React.createElement('em', null, 'his'),
+      React.createElement('em', { key: 'em' }, 'his'),
       ' fault'
     ])
   })
@@ -124,10 +126,10 @@ describe('react formatChildren with string tags', function () {
       strong: React.createElement('strong')
     })
     expect(results).to.deep.equal(
-      React.createElement('div', null,
-        React.createElement('span', null,
-          React.createElement('em', null,
-            React.createElement('strong', null, 'deep')
+      React.createElement('div', { key: 'div' },
+        React.createElement('span', { key: 'span' },
+          React.createElement('em', { key: 'em' },
+            React.createElement('strong', { key: 'strong' }, 'deep')
           )
         )
       )


### PR DESCRIPTION
Pass the tag name key from the message into applyChildren so that an
appropriate key can be added to each react element. This removes the
react warning by assuming the position in the array or object is
sufficient to know when to reuse the DOM node.

Closes #118