### PR TITLE
Adds Custom Rules Support To Lint CLI

### DIFF
--- a/packages/format-message-cli/lint-files.js
+++ b/packages/format-message-cli/lint-files.js
@@ -4,29 +4,38 @@ var fs = require('fs')
 var CLIEngine = require('eslint').CLIEngine
 
 module.exports = function extractFiles (files, options) {
+  var baseConfig = {
+    ecmaFeatures: {
+      modules: true,
+      experimentalObjectRestSpread: true,
+      jsx: true
+    },
+    parserOptions: {
+      ecmaVersion: 6,
+      sourceType: 'module'
+    },
+    plugins: [ 'format-message' ],
+    settings: {
+      'format-message': {
+        sourceLocale: options.locale,
+        generateId: options.generateId,
+        translations: options.translations
+      }
+    }
+  }
+  // This conditionally adds either the extends or rules config option.
+  // Both can not be set as rules always overrides extends even if rules does
+  // not have a valid value.
+  if (options.extends) {
+    baseConfig.extends = options.extends
+  }
+  if (options.customrules) {
+    baseConfig.rules = options.customrules
+  }
   var cli = new CLIEngine({
     useEslintrc: false,
     envs: [ 'es6', 'browser', 'node' ],
-    baseConfig: {
-      ecmaFeatures: {
-        modules: true,
-        experimentalObjectRestSpread: true,
-        jsx: true
-      },
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module'
-      },
-      plugins: [ 'format-message' ],
-      extends: [ 'plugin:format-message/default' ],
-      settings: {
-        'format-message': {
-          sourceLocale: options.locale,
-          generateId: options.generateId,
-          translations: options.translations
-        }
-      }
-    }
+    baseConfig: baseConfig
   })
 
   var report = {


### PR DESCRIPTION
This adds support for changing the lint rules that the format-message-cli linter applies. Before it would also use the default rules. 
Now it can either be default, recommended or custom. If custom is specified, a file with the custom rules has to be provided. 

I made this change because in our case we want to exclude one of the rules (format-message/no-missing-params) as it doesn't apply to our file structure. 