### PR TITLE
Add babel plugin to support dynamic imports

### DIFF
--- a/packages/format-message-cli/package.json
+++ b/packages/format-message-cli/package.json
@@ -35,6 +35,7 @@
     "babel-plugin-syntax-class-properties": "^6.13.0",
     "babel-plugin-syntax-decorators": "^6.13.0",
     "babel-plugin-syntax-do-expressions": "^6.13.0",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-syntax-exponentiation-operator": "^6.13.0",
     "babel-plugin-syntax-export-extensions": "^6.13.0",
     "babel-plugin-syntax-flow": "^6.18.0",

--- a/packages/format-message-cli/plugins.js
+++ b/packages/format-message-cli/plugins.js
@@ -5,6 +5,7 @@ module.exports = [
   require('babel-plugin-syntax-class-properties'),
   require('babel-plugin-syntax-decorators'),
   require('babel-plugin-syntax-do-expressions'),
+  require('babel-plugin-syntax-dynamic-import'),
   require('babel-plugin-syntax-exponentiation-operator'),
   require('babel-plugin-syntax-export-extensions'),
   require('babel-plugin-syntax-flow'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,6 +523,10 @@ babel-plugin-syntax-do-expressions@^6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz#5747756139aa26d390d09410b03744ba07e4796d"
 
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
+
 babel-plugin-syntax-exponentiation-operator@^6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"


### PR DESCRIPTION
This adds the [syntax-dynamic-import](https://www.npmjs.com/package/babel-plugin-syntax-dynamic-import) babel plugin, to allow `format-message-cli` to run in codebases that use dynamic imports.

Referenced issue: #156 