### PR TITLE
Add typescript declaration files

### DIFF
--- a/packages/format-message-formats/package.json
+++ b/packages/format-message-formats/package.json
@@ -9,5 +9,6 @@
   "bugs": "https://github.com/format-message/format-message/issues",
   "keywords": [
     "format-message"
-  ]
+  ],
+  "types": "types.d.ts"
 }

--- a/packages/format-message-formats/types.d.ts
+++ b/packages/format-message-formats/types.d.ts
@@ -1,10 +1,10 @@
-interface FormatGroup<T> {
+export interface FormatGroup<T> {
     default: T
 
     [style: string]: T
 }
 
-interface DurationFormatOptions {
+export interface DurationFormatOptions {
     hours: Intl.NumberFormatOptions
     minutes: Intl.NumberFormatOptions
     seconds: Intl.NumberFormatOptions

--- a/packages/format-message-formats/types.d.ts
+++ b/packages/format-message-formats/types.d.ts
@@ -1,18 +1,20 @@
-interface Format {
-    [option: string]: any
+interface FormatGroup<T> {
+    default: T
+
+    [style: string]: T
 }
 
-interface FormatGroup {
-    default: Format,
-
-    [style: string]: Format
+interface DurationFormatOptions {
+    hours: Intl.NumberFormatOptions
+    minutes: Intl.NumberFormatOptions
+    seconds: Intl.NumberFormatOptions
 }
 
-export declare const number: FormatGroup;
-export declare const date: FormatGroup;
-export declare const time: FormatGroup;
-export declare const duration: FormatGroup;
+export declare const number: FormatGroup<Intl.NumberFormatOptions>;
+export declare const date: FormatGroup<Intl.DateTimeFormatOptions>;
+export declare const time: FormatGroup<Intl.DateTimeFormatOptions>;
+export declare const duration: FormatGroup<DurationFormatOptions>;
 
-export declare function parseNumberPattern(pattern: string | undefined): Format;
+export declare function parseNumberPattern(pattern: string | undefined): Intl.NumberFormatOptions;
 
-export declare function parseDatePattern(pattern: string): Format;
+export declare function parseDatePattern(pattern: string): Intl.DateTimeFormatOptions;

--- a/packages/format-message-formats/types.d.ts
+++ b/packages/format-message-formats/types.d.ts
@@ -1,0 +1,18 @@
+interface Format {
+    [option: string]: any
+}
+
+interface FormatGroup {
+    default: Format,
+
+    [style: string]: Format
+}
+
+export declare const number: FormatGroup;
+export declare const date: FormatGroup;
+export declare const time: FormatGroup;
+export declare const duration: FormatGroup;
+
+export declare function parseNumberPattern(pattern: string | undefined): Format;
+
+export declare function parseDatePattern(pattern: string): Format;

--- a/packages/format-message-interpret/package.json
+++ b/packages/format-message-interpret/package.json
@@ -17,6 +17,7 @@
     "pluralformat",
     "selectformat"
   ],
+  "types": "types.d.ts",
   "dependencies": {
     "format-message-formats": "^6.1.0",
     "lookup-closest-locale": "^6.1.0"

--- a/packages/format-message-interpret/types.d.ts
+++ b/packages/format-message-interpret/types.d.ts
@@ -1,0 +1,18 @@
+import { AST, Placeholder } from 'format-message-parse';
+
+declare namespace interpret {
+    type Locale = string
+    type Locales = Locale | Locale[]
+    export type Type = (placeholder: Placeholder, locales: Locales) => (context: any, params?: object) => any
+
+    export interface Types {
+        [key: string]: Type
+    }
+
+    export function toParts(ast: AST, locale?: Locales, type?: Types): (args?: object) => any[];
+
+    export const types: Types;
+}
+
+declare function interpret(ast: AST, locale?: interpret.Locales, types?: interpret.Types): (args?: object) => string;
+export = interpret;

--- a/packages/format-message-interpret/types.d.ts
+++ b/packages/format-message-interpret/types.d.ts
@@ -3,8 +3,8 @@ import { AST, Placeholder } from 'format-message-parse';
 declare function interpret(ast: AST, locale?: interpret.Locales, types?: interpret.Types): (args?: object) => string;
 
 declare namespace interpret {
-    type Locale = string
-    type Locales = Locale | Locale[]
+    export type Locale = string
+    export type Locales = Locale | Locale[]
     export type Type = (placeholder: Placeholder, locales: Locales) => (context: any, params?: object) => any
 
     export interface Types {

--- a/packages/format-message-interpret/types.d.ts
+++ b/packages/format-message-interpret/types.d.ts
@@ -1,5 +1,7 @@
 import { AST, Placeholder } from 'format-message-parse';
 
+declare function interpret(ast: AST, locale?: interpret.Locales, types?: interpret.Types): (args?: object) => string;
+
 declare namespace interpret {
     type Locale = string
     type Locales = Locale | Locale[]
@@ -14,5 +16,4 @@ declare namespace interpret {
     export const types: Types;
 }
 
-declare function interpret(ast: AST, locale?: interpret.Locales, types?: interpret.Types): (args?: object) => string;
 export = interpret;

--- a/packages/format-message-parse/package.json
+++ b/packages/format-message-parse/package.json
@@ -16,5 +16,6 @@
     "messageformat",
     "pluralformat",
     "selectformat"
-  ]
+  ],
+  "types": "types.d.ts"
 }

--- a/packages/format-message-parse/types.d.ts
+++ b/packages/format-message-parse/types.d.ts
@@ -1,3 +1,10 @@
+interface ParseOptions {
+    tagsType?: string
+    tokens?: parse.Token[]
+}
+
+declare function parse(pattern: string, options?: ParseOptions): parse.AST;
+
 declare namespace parse {
     export type AST = Element[]
     export type Element = string | Placeholder
@@ -25,10 +32,4 @@ declare namespace parse {
     }
 }
 
-interface ParseOptions {
-    tagsType?: string
-    tokens?: parse.Token[]
-}
-
-declare function parse(pattern: string, options?: ParseOptions): parse.AST;
 export = parse;

--- a/packages/format-message-parse/types.d.ts
+++ b/packages/format-message-parse/types.d.ts
@@ -1,0 +1,34 @@
+declare namespace parse {
+    export type AST = Element[]
+    export type Element = string | Placeholder
+    export type Placeholder = Plural | Styled | Typed | Simple
+    export type Plural = [string, 'plural' | 'selectordinal', number, SubMessages]
+    export type Styled = [string, string, string | SubMessages]
+    export type Typed = [string, string]
+    export type Simple = [string]
+
+    export interface SubMessages {
+        [key: string]: AST
+    }
+
+    export type Token = [TokenType, string]
+    export type TokenType = 'text' | 'space' | 'id' | 'type' | 'style' | 'offset' | 'number' | 'selector' | 'syntax'
+
+    export class SyntaxError extends Error {
+        expected: string | undefined;
+        found: string | undefined;
+        offset: number;
+        line: number;
+        column: number;
+
+        constructor(message: string, expected: string | undefined, found: string | undefined, offset: number, line: number, column: number)
+    }
+}
+
+interface ParseOptions {
+    tagsType?: string
+    tokens?: parse.Token[]
+}
+
+declare function parse(pattern: string, options?: ParseOptions): parse.AST;
+export = parse;

--- a/packages/format-message-parse/types.d.ts
+++ b/packages/format-message-parse/types.d.ts
@@ -1,9 +1,4 @@
-interface ParseOptions {
-    tagsType?: string
-    tokens?: parse.Token[]
-}
-
-declare function parse(pattern: string, options?: ParseOptions): parse.AST;
+declare function parse(pattern: string, options?: parse.ParseOptions): parse.AST;
 
 declare namespace parse {
     export type AST = Element[]
@@ -20,6 +15,12 @@ declare namespace parse {
 
     export type Token = [TokenType, string]
     export type TokenType = 'text' | 'space' | 'id' | 'type' | 'style' | 'offset' | 'number' | 'selector' | 'syntax'
+
+    export interface ParseOptions {
+        tagsType?: string
+        tokens?: parse.Token[]
+    }
+
 
     export class SyntaxError extends Error {
         expected: string | undefined;

--- a/packages/format-message-print/package.json
+++ b/packages/format-message-print/package.json
@@ -9,5 +9,6 @@
   "bugs": "https://github.com/format-message/format-message/issues",
   "keywords": [
     "format-message"
-  ]
+  ],
+  "types": "types.d.ts"
 }

--- a/packages/format-message-print/types.d.ts
+++ b/packages/format-message-print/types.d.ts
@@ -1,0 +1,4 @@
+import { AST } from 'format-message-parse';
+
+declare function print(ast: AST): string;
+export = print;

--- a/packages/format-message-print/types.d.ts
+++ b/packages/format-message-print/types.d.ts
@@ -1,4 +1,5 @@
 import { AST } from 'format-message-parse';
 
 declare function print(ast: AST): string;
+
 export = print;

--- a/packages/format-message/package.json
+++ b/packages/format-message/package.json
@@ -20,6 +20,7 @@
     "gender",
     "icu"
   ],
+  "types": "types.d.ts",
   "dependencies": {
     "format-message-formats": "^6.1.0",
     "format-message-interpret": "^6.1.0",

--- a/packages/format-message/types.d.ts
+++ b/packages/format-message/types.d.ts
@@ -1,0 +1,82 @@
+import { Types } from 'format-message-interpret';
+
+type Locale = string
+type Locales = Locale | Locale[]
+type Message = string | {
+    id?: string,
+    default: string,
+    description?: string
+}
+
+interface Translations {
+    [key: string]: { [key: string]: string | Translation } | undefined
+}
+
+interface Translation {
+    message: string,
+    format?: (args?: object) => string,
+    toParts?: (args?: object) => any[],
+}
+
+type Replacement = string | null | undefined | ((a: string, b: string, locales?: Locales) => string | undefined)
+type GenerateId = (source: string) => string
+type MissingTranslation = 'ignore' | 'warning' | 'error'
+
+interface FormatObject {
+    [key: string]: any
+}
+
+interface Options {
+    locale?: Locales,
+    translations?: Translations,
+    generateId?: GenerateId,
+    missingReplacement?: Replacement,
+    missingTranslation?: MissingTranslation,
+    formats?: {
+        number?: FormatObject,
+        date?: FormatObject,
+        time?: FormatObject
+    },
+    types?: Types
+}
+
+interface Setup {
+    locale: Locales,
+    translations: Translations,
+    generateId: GenerateId,
+    missingReplacement: Replacement,
+    missingTranslation: MissingTranslation,
+    formats: {
+        number: FormatObject,
+        date: FormatObject,
+        time: FormatObject
+    },
+    types: Types
+}
+
+interface FormatMessage {
+    (msg: Message, args?: object, locales?: Locales): string,
+
+    rich(msg: Message, args?: object, locales?: Locales): any[],
+
+    setup(opt?: Options): Setup,
+
+    number(value: number, style?: string, locales?: Locales): string,
+
+    date(value: number | Date, style?: string, locales?: Locales): string,
+
+    time(value: number | Date, style?: string, locales?: Locales): string,
+
+    select(value: any, options: object): any,
+
+    custom(placeholder: any[], locales: Locales, value: any, args: object): any,
+
+    plural(value: number, offset: any, options: any, locale: any): any,
+
+    selectordinal(value: number, offset: any, options: any, locale: any): any,
+
+    namespace(): FormatMessage
+}
+
+declare const formatMessage: FormatMessage;
+export = formatMessage;

--- a/packages/format-message/types.d.ts
+++ b/packages/format-message/types.d.ts
@@ -1,82 +1,88 @@
 import { Types } from 'format-message-interpret';
 
-type Locale = string
-type Locales = Locale | Locale[]
-type Message = string | {
-    id?: string,
-    default: string,
-    description?: string
+declare function formatMessage(msg: formatMessage.Message, args?: object, locales?: formatMessage.Locales): string
+
+declare namespace formatMessage {
+    export type Locale = string
+    export type Locales = Locale | Locale[]
+
+    export interface MessageObject {
+        id?: string
+        default: string
+        description?: string
+    }
+
+    export type Message = string | MessageObject
+
+    export interface Translations {
+        [key: string]: { [key: string]: string | Translation } | undefined
+    }
+
+    export interface Translation {
+        message: string
+        format?: (args?: object) => string
+        toParts?: (args?: object) => any[]
+    }
+
+    type ReplacementFunction = ((a: string, b: string, locales?: Locales) => string | undefined)
+
+    export type Replacement = string | null | undefined | ReplacementFunction
+
+    export type GenerateId = (source: string) => string
+
+    export type MissingTranslation = 'ignore' | 'warning' | 'error'
+
+    export interface FormatObject {
+        [key: string]: any
+    }
+
+    export interface SetupOptions {
+        locale?: Locales
+        translations?: Translations
+        generateId?: GenerateId
+        missingReplacement?: Replacement
+        missingTranslation?: MissingTranslation
+        formats?: {
+            number?: FormatObject
+            date?: FormatObject
+            time?: FormatObject
+        },
+        types?: Types
+    }
+
+    export interface Setup {
+        locale: Locales
+        translations: Translations
+        generateId: GenerateId
+        missingReplacement: Replacement
+        missingTranslation: MissingTranslation
+        formats: {
+            number: FormatObject
+            date: FormatObject
+            time: FormatObject
+        },
+        types: Types
+    }
+
+    export function rich(msg: Message, args?: object, locales?: Locales): any[]
+
+    export function setup(opt?: SetupOptions): Setup
+
+    export function number(value: number, style?: string, locales?: Locales): string
+
+    export function date(value: number | Date, style?: string, locales?: Locales): string
+
+    export function time(value: number | Date, style?: string, locales?: Locales): string
+
+    export function select(value: any, options: object): any
+
+    export function custom(placeholder: any[], locales: Locales, value: any, args: object): any
+
+    export function plural(value: number, offset: any, options: any, locale: any): any
+
+    export function selectordinal(value: number, offset: any, options: any, locale: any): any
+
+    export function namespace(): typeof formatMessage
 }
 
-interface Translations {
-    [key: string]: { [key: string]: string | Translation } | undefined
-}
-
-interface Translation {
-    message: string,
-    format?: (args?: object) => string,
-    toParts?: (args?: object) => any[],
-}
-
-type Replacement = string | null | undefined | ((a: string, b: string, locales?: Locales) => string | undefined)
-type GenerateId = (source: string) => string
-type MissingTranslation = 'ignore' | 'warning' | 'error'
-
-interface FormatObject {
-    [key: string]: any
-}
-
-interface Options {
-    locale?: Locales,
-    translations?: Translations,
-    generateId?: GenerateId,
-    missingReplacement?: Replacement,
-    missingTranslation?: MissingTranslation,
-    formats?: {
-        number?: FormatObject,
-        date?: FormatObject,
-        time?: FormatObject
-    },
-    types?: Types
-}
-
-interface Setup {
-    locale: Locales,
-    translations: Translations,
-    generateId: GenerateId,
-    missingReplacement: Replacement,
-    missingTranslation: MissingTranslation,
-    formats: {
-        number: FormatObject,
-        date: FormatObject,
-        time: FormatObject
-    },
-    types: Types
-}
-
-interface FormatMessage {
-    (msg: Message, args?: object, locales?: Locales): string,
-
-    rich(msg: Message, args?: object, locales?: Locales): any[],
-
-    setup(opt?: Options): Setup,
-
-    number(value: number, style?: string, locales?: Locales): string,
-
-    date(value: number | Date, style?: string, locales?: Locales): string,
-
-    time(value: number | Date, style?: string, locales?: Locales): string,
-
-    select(value: any, options: object): any,
-
-    custom(placeholder: any[], locales: Locales, value: any, args: object): any,
-
-    plural(value: number, offset: any, options: any, locale: any): any,
-
-    selectordinal(value: number, offset: any, options: any, locale: any): any,
-
-    namespace(): FormatMessage
-}
-
-declare const formatMessage: FormatMessage;
-export = formatMessage;
+export = formatMessage

--- a/packages/lookup-closest-locale/package.json
+++ b/packages/lookup-closest-locale/package.json
@@ -12,5 +12,6 @@
     "lookup",
     "BCP47",
     "language tag"
-  ]
+  ],
+  "types": "types.d.ts"
 }

--- a/packages/lookup-closest-locale/types.d.ts
+++ b/packages/lookup-closest-locale/types.d.ts
@@ -1,0 +1,3 @@
+declare function lookupClosestLocale(locale: string | string[] | undefined, available: { [key: string]: any }): string | undefined;
+
+export = lookupClosestLocale;

--- a/packages/message-format/package.json
+++ b/packages/message-format/package.json
@@ -21,6 +21,7 @@
     "gender",
     "icu"
   ],
+  "types": "types.d.ts",
   "dependencies": {
     "format-message-interpret": "^6.1.0",
     "format-message-parse": "^6.1.0"

--- a/packages/message-format/types.d.ts
+++ b/packages/message-format/types.d.ts
@@ -1,0 +1,17 @@
+import { Types } from 'format-message-interpret';
+import { AST, Placeholder } from 'format-message-parse';
+
+interface Options {
+    types: Types
+}
+
+declare class MessageFormat {
+    format: (args?: object) => string;
+    formatToParts: (args?: object) => Placeholder;
+    resolvedOptions: () => { locale: string | string[] | undefined };
+    supportedLocalesOf: (requestedLocales?: string | string[]) => string[];
+
+    constructor(pattern: string, locales?: string | string[], options?: Options);
+}
+
+export = MessageFormat;

--- a/packages/message-format/types.d.ts
+++ b/packages/message-format/types.d.ts
@@ -1,17 +1,19 @@
 import { Types } from 'format-message-interpret';
 import { AST, Placeholder } from 'format-message-parse';
 
-interface Options {
-    types: Types
-}
-
 declare class MessageFormat {
     format: (args?: object) => string;
     formatToParts: (args?: object) => Placeholder;
     resolvedOptions: () => { locale: string | string[] | undefined };
     supportedLocalesOf: (requestedLocales?: string | string[]) => string[];
 
-    constructor(pattern: string, locales?: string | string[], options?: Options);
+    constructor(pattern: string, locales?: string | string[], options?: MessageFormat.MessageFormatOptions);
+}
+
+declare namespace MessageFormat {
+    export interface MessageFormatOptions {
+        types: Types
+    }
 }
 
 export = MessageFormat;


### PR DESCRIPTION
Fixes #205 

I'm not sure about `format-message-formats` - what's API, what's data that may change?

Generally, I only exported types that flow also exported. For `format-message`, it might however be useful to export some types that are used within `Options`, what do you think?

The declaration of  a `namespace` and a `function` is TypeScript's way to declare `module.exports = ` together with `exports.* = `. Having only ES6 named/default exports would be nicer, but this is a pretty common pattern, too.

We could declare everything as `readonly` / use `ReadonlyArray` to document immutability if you don't modify arguments (which I hope).