### PR TITLE
Replaced rawgit.com urls with combinatronics.com urls.

### DIFF
--- a/packages/format-message-parse/README.md
+++ b/packages/format-message-parse/README.md
@@ -69,7 +69,7 @@ License
 This software is free to use under the MIT license. See the [LICENSE-MIT file][LICENSE] for license text and copyright information.
 
 
-[logo]: https://cdn.rawgit.com/format-message/format-message/2febdd8/logo.svg
+[logo]: https://cdn.combinatronics.com/format-message/format-message/2febdd8/logo.svg
 [npm]: https://www.npmjs.org/package/format-message-parse
 [npm-image]: https://img.shields.io/npm/v/format-message-parse.svg
 [style]: https://github.com/feross/standard


### PR DESCRIPTION
Combinatronics.com is a drop in replacement for rawgit.com which is EOL.