### PR TITLE
Add TypeScript signature for `plural` method

### DIFF
--- a/packages/format-message/types.d.ts
+++ b/packages/format-message/types.d.ts
@@ -80,6 +80,8 @@ declare namespace formatMessage {
 
     export function plural(value: number, offset: any, options: any, locale: any): any
 
+    export function plural(value: number, options: any): any
+
     export function selectordinal(value: number, offset: any, options: any, locale: any): any
 
     export function namespace(): typeof formatMessage


### PR DESCRIPTION
the `plural` method is built to handle different sets of params. Though it takes four params, it allows for `offset` and `locale` to be ignored, and handles supplying only `value` and `options`. In order to support this with TypeScript, I've added an overloaded signature for `plural`, which accepts `value` and `options`.