### PR TITLE
Add rich test cases for translation-match-params

### DIFF
--- a/packages/eslint-plugin-format-message/__tests__/locales.json
+++ b/packages/eslint-plugin-format-message/__tests__/locales.json
@@ -1,4 +1,31 @@
 {
-  "en": { "a": "a", "b": "b", "c": "{c}", "d": "d", "{ k }":"{ k }", "same":"same", "{i}":"{i}", "{ o, select, \nother {o} }":"{o,select,other{o}}", "{ o, plural, \nother {o} }":"{ o, plural, \nother {o} }" },
-  "pt": { "a": "a1", "b": "b2", "c": "c3", "bad1": "{", "bad2": "{z}", "{ k }":"{y}", "same":"same", "{i}":"{i}", "{ o, select, \nother {o} }":"{ o, select, \nother {o} }", "{ o, plural, \nother {o} }":"{ o, plural, \nother {o} }" }
+  "en": {
+    "a": "a",
+    "b": "b",
+    "c": "{c}",
+    "d": "d",
+    "{ k }": "{ k }",
+    "same": "same",
+    "{i}": "{i}",
+    "{ o, select, \nother {o} }": "{o,select,other{o}}",
+    "{ o, plural, \nother {o} }": "{ o, plural, \nother {o} }",
+    "<b>c</b>": "<b>c</b>",
+    "<i>d</i>": "<i>d</i>",
+    "<u>e</u>": "<u>e</u>"
+  },
+  "pt": {
+    "a": "a1",
+    "b": "b2",
+    "c": "c3",
+    "bad1": "{",
+    "bad2": "{z}",
+    "{ k }": "{y}",
+    "same": "same",
+    "{i}": "{i}",
+    "{ o, select, \nother {o} }": "{ o, select, \nother {o} }",
+    "{ o, plural, \nother {o} }": "{ o, plural, \nother {o} }",
+    "<b>c</b>": "<b>c</b>",
+    "<i>d</i>": "d",
+    "<u>e</u>": "{u}e"
+  }
 }

--- a/packages/eslint-plugin-format-message/__tests__/rules/translation-match-params.spec.js
+++ b/packages/eslint-plugin-format-message/__tests__/rules/translation-match-params.spec.js
@@ -22,6 +22,14 @@ tester.run('translation-match-params', rule, {
       code: '<a translate="yes">d</a>',
       settings: settings,
       parserOptions: { ecmaFeatures: { jsx: true } }
+    },
+    {
+      code: 'var f=require("format-message");' +
+        'f.rich("<b>c</b>", { ' +
+          'b: function(props) { return <b>{props.children}</b> } ' +
+        '})',
+      settings: settings,
+      parserOptions: { ecmaFeatures: { jsx: true } }
     }
   ],
   invalid: [
@@ -50,6 +58,28 @@ tester.run('translation-match-params', rule, {
       errors: [
         { message: 'Translation for "{ k }" in "pt" is missing "k" placeholder' },
         { message: 'Translation for "{ k }" in "pt" has extra "y" placeholder' }
+      ]
+    },
+    {
+      code: 'var f=require("format-message");' +
+        'f.rich("<i>d</i>", { ' +
+          'i: function(props) { return <i>{props.children}</i> } ' +
+        '})',
+      settings: settings,
+      parserOptions: { ecmaFeatures: { jsx: true } },
+      errors: [
+        'Translation for "<i>d</i>" in "pt" is missing "i" placeholder'
+      ]
+    },
+    {
+      code: 'var f=require("format-message");' +
+        'f.rich("<u>e</u>", { ' +
+          'u: function(props) { return <u>{props.children}</u> } ' +
+        '})',
+      settings: settings,
+      parserOptions: { ecmaFeatures: { jsx: true } },
+      errors: [
+        'Translation for "<u>e</u>" in "pt" is missing "u" placeholder'
       ]
     }
   ]


### PR DESCRIPTION
Added a few test cases that should probably be handled:
1. When all locales include the tags (the main issue of #256)
2. When a locale does not include the tags
3. When a locale uses a `{placeholder}` instead of a tag

I also reformatted the `locales.json` file used in the tests to make it slightly easier to work with. The single line for each locale was starting to get pretty long.

Let me know what you think of the test cases. I haven't looked at what it would take to fix these cases yet. I thought I'd get these changes up first before looking into that.