### PR TITLE
Handle rich text params in match params rule

### DIFF
--- a/packages/eslint-plugin-format-message/__tests__/locales.json
+++ b/packages/eslint-plugin-format-message/__tests__/locales.json
@@ -11,7 +11,10 @@
     "{ o, plural, \nother {o} }": "{ o, plural, \nother {o} }",
     "<b>c</b>": "<b>c</b>",
     "<i>d</i>": "<i>d</i>",
-    "<u>e</u>": "<u>e</u>"
+    "<u>e</u>": "<u>e</u>",
+    "<p>{f}</p>": "<p>{f}</p>",
+    "<q>g</q>": "<q>g</q>",
+    "<s />": "<s />"
   },
   "pt": {
     "a": "a1",
@@ -26,6 +29,9 @@
     "{ o, plural, \nother {o} }": "{ o, plural, \nother {o} }",
     "<b>c</b>": "<b>c</b>",
     "<i>d</i>": "d",
-    "<u>e</u>": "{u}e"
+    "<u>e</u>": "{u}e",
+    "<p>{f}</p>": "<p></p>",
+    "<q>g</q>": "{<q>}g",
+    "<s />": "<s />"
   }
 }

--- a/packages/eslint-plugin-format-message/__tests__/rules/translation-match-params.spec.js
+++ b/packages/eslint-plugin-format-message/__tests__/rules/translation-match-params.spec.js
@@ -30,6 +30,13 @@ tester.run('translation-match-params', rule, {
         '})',
       settings: settings,
       parserOptions: { ecmaFeatures: { jsx: true } }
+    },
+    {
+      code: 'var f=require("format-message");' +
+        'f.rich("<s />", { ' +
+          's: function(props) { return props } ' +
+        '})',
+      settings: settings
     }
   ],
   invalid: [
@@ -68,7 +75,7 @@ tester.run('translation-match-params', rule, {
       settings: settings,
       parserOptions: { ecmaFeatures: { jsx: true } },
       errors: [
-        'Translation for "<i>d</i>" in "pt" is missing "i" placeholder'
+        'Translation for "<i>d</i>" in "pt" is missing rich text "<i>" placeholder'
       ]
     },
     {
@@ -79,7 +86,31 @@ tester.run('translation-match-params', rule, {
       settings: settings,
       parserOptions: { ecmaFeatures: { jsx: true } },
       errors: [
-        'Translation for "<u>e</u>" in "pt" is missing "u" placeholder'
+        'Translation for "<u>e</u>" in "pt" is missing rich text "<u>" placeholder',
+        'Translation for "<u>e</u>" in "pt" has extra "u" placeholder'
+      ]
+    },
+    {
+      code: 'var f=require("format-message");' +
+        'f.rich("<p>{f}</p>", { ' +
+          'p: function(props) { return <p>{props.children}</p> } ' +
+        '})',
+      settings: settings,
+      parserOptions: { ecmaFeatures: { jsx: true } },
+      errors: [
+        'Translation for "<p>{f}</p>" in "pt" is missing "f" placeholder'
+      ]
+    },
+    {
+      code: 'var f=require("format-message");' +
+        'f.rich("<q>g</q>", { ' +
+          'q: function(props) { return <q>{props.children}</q> } ' +
+        '})',
+      settings: settings,
+      parserOptions: { ecmaFeatures: { jsx: true } },
+      errors: [
+        'Translation for "<q>g</q>" in "pt" is missing rich text "<q>" placeholder',
+        'Translation for "<q>g</q>" in "pt" has extra "<q>" placeholder'
       ]
     }
   ]

--- a/packages/eslint-plugin-format-message/lib/rules/translation-match-params.js
+++ b/packages/eslint-plugin-format-message/lib/rules/translation-match-params.js
@@ -4,6 +4,10 @@ var parse = require('format-message-parse')
 var getParamsFromPatternAst = require('../util/get-params-from-pattern-ast')
 var visitEachTranslation = require('../util/visit-each-translation')
 
+function isRichTextParam (paramName) {
+  return typeof paramName === 'object' && paramName.isRich === true
+}
+
 module.exports = {
   meta: {
     schema: []
@@ -16,30 +20,33 @@ module.exports = {
       var locale = info.locale
       var patternParams = info.patternParams
       var translation = info.translation
+      var isRich = info.isRich
 
       var translationAst
       try {
-        translationAst = parse(translation)
+        translationAst = parse(translation, { tagsType: isRich ? '<>' : null })
       } catch (err) {
         return // error handled elsewhere
       }
 
-      var translationParams = getParamsFromPatternAst(translationAst)
+      var translationParams = getParamsFromPatternAst(translationAst, isRich)
       patternParams.forEach(function (paramName) {
         if (translationParams.indexOf(paramName) < 0) {
+          var paramType = isRichTextParam(paramName) ? 'rich text ' : ''
           context.report(
             (node.arguments && node.arguments[0]) || node,
-            'Translation for "' + id + '" in "' + locale + '" is missing "' +
-              paramName + '" placeholder'
+            'Translation for "' + id + '" in "' + locale + '" is missing ' +
+              paramType + '"' + paramName + '" placeholder'
           )
         }
       })
       translationParams.forEach(function (paramName) {
         if (patternParams.indexOf(paramName) < 0) {
+          var paramType = isRichTextParam(paramName) ? 'rich text ' : ''
           context.report(
             (node.arguments && node.arguments[0]) || node,
-            'Translation for "' + id + '" in "' + locale + '" has extra "' +
-              paramName + '" placeholder'
+            'Translation for "' + id + '" in "' + locale + '" has extra ' +
+              paramType + '"' + paramName + '" placeholder'
           )
         }
       })

--- a/packages/eslint-plugin-format-message/lib/util/get-common-translation-info.js
+++ b/packages/eslint-plugin-format-message/lib/util/get-common-translation-info.js
@@ -37,7 +37,7 @@ function getInfo (message, locale, isRich) {
       // ignore parse error here
     }
     if (info.patternAst) {
-      info.patternParams = getParamsFromPatternAst(info.patternAst)
+      info.patternParams = getParamsFromPatternAst(info.patternAst, isRich)
     }
   }
 

--- a/packages/eslint-plugin-format-message/lib/util/get-params-from-pattern-ast.js
+++ b/packages/eslint-plugin-format-message/lib/util/get-params-from-pattern-ast.js
@@ -1,6 +1,22 @@
 'use strict'
 
-module.exports = function getParamsFromPatternAst (ast) {
+var richTagCache = []
+function getRichTag (name) {
+  var cachedTag = richTagCache.find(function (cacheEntry) {
+    return cacheEntry.name === name
+  })
+  if (cachedTag) return cachedTag
+
+  var tag = {
+    isRich: true,
+    name: name,
+    toString: function () { return '<' + name + '>' }
+  }
+  richTagCache.push(tag)
+  return tag
+}
+
+module.exports = function getParamsFromPatternAst (ast, isRich) {
   if (!ast || !ast.slice) return []
   var stack = ast.slice()
   var params = []
@@ -10,11 +26,17 @@ module.exports = function getParamsFromPatternAst (ast) {
     if (element.length === 1 && element[0] === '#') continue
 
     var name = element[0]
+    var type = element[1]
+    var isRichParam = isRich && type === '<>'
+
+    if (isRichParam) {
+      name = getRichTag(name)
+    }
     if (params.indexOf(name) < 0) params.push(name)
 
-    var type = element[1]
-    if (type === 'select' || type === 'plural' || type === 'selectordinal') {
-      var children = type === 'select' ? element[2] : element[3]
+    if (type === 'select' || type === 'plural' || type === 'selectordinal' || isRichParam) {
+      var children = type === 'select' || isRichParam ? element[2] : element[3]
+      if (!children) continue
       stack = stack.concat.apply(stack,
         Object.keys(children).map(function (key) { return children[key] })
       )


### PR DESCRIPTION
This is what I came up with to fix #256.

In `getParamsFromPatternAst`, in order to differentiate between regular params and rich text params, the rich text params are objects with a `toString` method that returns the param name wrapped in angle brackets (e.g. `"<a>"`). These objects are cached, so that `params.indexOf(name)` will still work, since we would be comparing the same object instances.

The output of the `translation-match-params` eslint rule was change slightly for rich text params, too. If the missing/extra param is a rich text param, the words "rich text" are included in the output to better differentiate between regular params and rich text params.