### PR TITLE
Bump version to 6.2.2

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.5.1",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/babel-plugin-extract-format-message/package.json
+++ b/packages/babel-plugin-extract-format-message/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-extract-format-message",
-  "version": "6.2.0",
+  "version": "6.2.2",
   "description": "Generate a message id from the default message pattern",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/babel-plugin-extract-format-message",
@@ -12,8 +12,8 @@
   ],
   "dependencies": {
     "format-message-estree-util": "^6.1.0",
-    "format-message-generate-id": "^6.2.0",
-    "format-message-parse": "^6.2.0",
-    "format-message-print": "^6.2.0"
+    "format-message-generate-id": "^6.2.2",
+    "format-message-parse": "^6.2.2",
+    "format-message-print": "^6.2.2"
   }
 }

--- a/packages/babel-plugin-transform-format-message/package.json
+++ b/packages/babel-plugin-transform-format-message/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-format-message",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "Pre-generate ids from default messages or inline a single language translation",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/babel-plugin-transform-format-message",
@@ -13,11 +13,11 @@
   "dependencies": {
     "@babel/helper-module-imports": "^7.0.0",
     "@babel/parser": "^7.0.0",
-    "format-message": "^6.2.1",
+    "format-message": "^6.2.2",
     "format-message-estree-util": "^6.1.0",
     "format-message-formats": "^6.2.0",
-    "format-message-generate-id": "^6.2.0",
-    "format-message-parse": "^6.2.0",
+    "format-message-generate-id": "^6.2.2",
+    "format-message-parse": "^6.2.2",
     "lookup-closest-locale": "^6.2.0",
     "source-map": "^0.5.7"
   }

--- a/packages/eslint-plugin-format-message/CHANGELOG.md
+++ b/packages/eslint-plugin-format-message/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.2.2
+
+Handle rich text parameters in `translation-match-params` rule.
+
 ## 6.2.0
 
 Add TypeScript type definitions.

--- a/packages/eslint-plugin-format-message/package.json
+++ b/packages/eslint-plugin-format-message/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-format-message",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "format-message i18n specific rules for ESLint",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/eslint-plugin-format-message",
@@ -23,10 +23,10 @@
     "icu"
   ],
   "dependencies": {
-    "format-message": "^6.2.1",
+    "format-message": "^6.2.2",
     "format-message-estree-util": "^6.1.0",
-    "format-message-generate-id": "^6.2.0",
-    "format-message-parse": "^6.2.0",
+    "format-message-generate-id": "^6.2.2",
+    "format-message-parse": "^6.2.2",
     "lookup-closest-locale": "^6.2.0"
   },
   "peerDependencies": {

--- a/packages/format-message-cli/package.json
+++ b/packages/format-message-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "format-message-cli",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "Command-line tools to lint, extract, and inline format-message translations",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/format-message-cli",
@@ -28,11 +28,11 @@
   },
   "dependencies": {
     "@babel/core": "^7.0.0",
-    "babel-plugin-extract-format-message": "^6.2.0",
-    "babel-plugin-transform-format-message": "^6.2.1",
+    "babel-plugin-extract-format-message": "^6.2.2",
+    "babel-plugin-transform-format-message": "^6.2.2",
     "commander": "^2.11.0",
     "eslint": "^3.19.0",
-    "eslint-plugin-format-message": "^6.2.1",
+    "eslint-plugin-format-message": "^6.2.2",
     "glob": "^5.0.15",
     "js-yaml": "^3.10.0",
     "mkdirp": "^0.5.1",

--- a/packages/format-message-generate-id/package.json
+++ b/packages/format-message-generate-id/package.json
@@ -1,6 +1,6 @@
 {
   "name": "format-message-generate-id",
-  "version": "6.2.0",
+  "version": "6.2.2",
   "description": "Generate a message id from the default message pattern",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/format-message-generate-id",
@@ -12,7 +12,7 @@
   ],
   "dependencies": {
     "crc32": "^0.2.2",
-    "format-message-parse": "^6.2.0",
-    "format-message-print": "^6.2.0"
+    "format-message-parse": "^6.2.2",
+    "format-message-print": "^6.2.2"
   }
 }

--- a/packages/format-message-interpret/package.json
+++ b/packages/format-message-interpret/package.json
@@ -1,6 +1,6 @@
 {
   "name": "format-message-interpret",
-  "version": "6.2.0",
+  "version": "6.2.2",
   "description": "Convert format-message-parse ast to a function",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/format-message-interpret",

--- a/packages/format-message-parse/package.json
+++ b/packages/format-message-parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "format-message-parse",
-  "version": "6.2.0",
+  "version": "6.2.2",
   "description": "Parse ICU MessageFormat pattern strings to a compact ast",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/format-message-parse",

--- a/packages/format-message-print/package.json
+++ b/packages/format-message-print/package.json
@@ -1,6 +1,6 @@
 {
   "name": "format-message-print",
-  "version": "6.2.0",
+  "version": "6.2.2",
   "description": "Pretty print compact message format ast",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/format-message-print",

--- a/packages/format-message/package.json
+++ b/packages/format-message/package.json
@@ -1,6 +1,6 @@
 {
   "name": "format-message",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "Internationalize text, numbers, and dates using ICU Message Format",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message",
@@ -23,8 +23,8 @@
   "types": "types.d.ts",
   "dependencies": {
     "format-message-formats": "^6.2.0",
-    "format-message-interpret": "^6.2.0",
-    "format-message-parse": "^6.2.0",
+    "format-message-interpret": "^6.2.2",
+    "format-message-parse": "^6.2.2",
     "lookup-closest-locale": "^6.2.0"
   }
 }

--- a/packages/message-format/package.json
+++ b/packages/message-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-format",
-  "version": "6.2.0",
+  "version": "6.2.2",
   "description": "Intl.MessageFormat prollyfill supporting ICU message format",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/message-format",
@@ -23,7 +23,7 @@
   ],
   "types": "types.d.ts",
   "dependencies": {
-    "format-message-interpret": "^6.2.0",
-    "format-message-parse": "^6.2.0"
+    "format-message-interpret": "^6.2.2",
+    "format-message-parse": "^6.2.2"
   }
 }


### PR DESCRIPTION
Since lerna is being used for this project, I used the [`lerna version` command](https://github.com/lerna/lerna/tree/457d1e8a/commands/version) to bump the version number. This didn't seem like it would be a breaking change, and the only significant change appeared to be the fix for the eslint plugin, so I went with 6.2.2 as the new version.

I also updated the changelog for the eslint plugin with a short blurb about what changed.