### PR TITLE
ignore "format-message" file extension during parse

### DIFF
--- a/packages/format-message-estree-util/index.js
+++ b/packages/format-message-estree-util/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var MODULE_NAME_PATTERN = /(^|\/)format-message$/
+var MODULE_NAME_PATTERN = /(^|\/)format-message(\.js)?$/
 
 exports = module.exports = {
   setBabelContext: function (path, state) {


### PR DESCRIPTION
the parser is not following imports that specify "format-message.js",
which is the output of recent babel transpilation