### PR TITLE
message-format: fix types.d.ts file to expose `supportedLocalesOf()` as a static method

### DIFF
--- a/packages/message-format/types.d.ts
+++ b/packages/message-format/types.d.ts
@@ -5,7 +5,7 @@ declare class MessageFormat {
     format: (args?: object) => string;
     formatToParts: (args?: object) => Placeholder;
     resolvedOptions: () => { locale: string | string[] | undefined };
-    supportedLocalesOf: (requestedLocales?: string | string[]) => string[];
+    static supportedLocalesOf: (requestedLocales?: string | string[]) => string[];
 
     constructor(pattern: string, locales?: string | string[], options?: MessageFormat.MessageFormatOptions);
 }


### PR DESCRIPTION
Accordingly to [tests](https://github.com/format-message/format-message/blob/master/packages/message-format/__tests__/index.spec.js#L59) the `MessageFormat.supportedLocalesOf()` is a static method. This PR fixes type definitions