### PR TITLE
Make `MODULE_NAME_PATTERN` more flexible

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,10 +7,14 @@ pool:
   vmImage: 'ubuntu-latest'
 strategy:
   matrix:
-    node_8_x:
-      node_version: 8.x
     node_10_x:
       node_version: 10.x
+    node_12_x:
+      node_version: 12.x
+    node_14_x:
+      node_version: 14.x
+    node_16_x:
+      node_version: 16.x
 
 steps:
 - task: NodeTool@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,8 +7,6 @@ pool:
   vmImage: 'ubuntu-latest'
 strategy:
   matrix:
-    node_10_x:
-      node_version: 10.x
     node_12_x:
       node_version: 12.x
     node_14_x:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 pool:
-  vmImage: 'Ubuntu 16.04'
+  vmImage: 'ubuntu-latest'
 strategy:
   matrix:
     node_8_x:

--- a/packages/format-message-estree-util/index.js
+++ b/packages/format-message-estree-util/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var MODULE_NAME_PATTERN = /(^|\/|\.|-)format-message$/
+var MODULE_NAME_PATTERN = /\bformat-message$/
 
 exports = module.exports = {
   setBabelContext: function (path, state) {

--- a/packages/format-message-estree-util/index.js
+++ b/packages/format-message-estree-util/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var MODULE_NAME_PATTERN = /(^|\/)format-message$/
+var MODULE_NAME_PATTERN = /(^|\/|\.|-)format-message$/
 
 exports = module.exports = {
   setBabelContext: function (path, state) {

--- a/packages/format-message-interpret/__tests__/index.spec.js
+++ b/packages/format-message-interpret/__tests__/index.spec.js
@@ -52,7 +52,7 @@ describe('interpret()', function () {
   it('interprets bad number values gracefully', function () {
     var format = interpret([['n', 'number']], 'en')
     expect(format({ n: 0 })).to.equal('0')
-    expect(format({ n: -0 })).to.equal('0')
+    expect(format({ n: -0 })).to.equal('-0')
     expect(format({ n: '' })).to.equal('0')
     expect(format({ n: false })).to.equal('0')
     expect(format({ n: true })).to.equal('1')


### PR DESCRIPTION
Right now, format-message looks for itself being imported via the following patterns:

* `import t from 'format-message'`
* `import t from 'foo/format-message'`

In other words, the import must match `'format-message'` exactly or be prepended by a slash. This commit expands upon this to also allow imports that match these patterns:

* `import t from 'foo-format-message'`
* `import t from 'foo.format-message'`

In other words, the character that prepends `format-message` can now be a dash or a period.

This gives format-message consumers more flexibility with naming/importing their own libraries that wrap format-message. (See also: https://github.com/format-message/format-message/issues/232)