### PR TITLE
Bump version to 6.2.4

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.5.1",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/babel-plugin-extract-format-message/package.json
+++ b/packages/babel-plugin-extract-format-message/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-extract-format-message",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "Generate a message id from the default message pattern",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/babel-plugin-extract-format-message",
@@ -11,9 +11,9 @@
     "format-message"
   ],
   "dependencies": {
-    "format-message-estree-util": "^6.1.0",
-    "format-message-generate-id": "^6.2.3",
-    "format-message-parse": "^6.2.3",
-    "format-message-print": "^6.2.3"
+    "format-message-estree-util": "^6.2.4",
+    "format-message-generate-id": "^6.2.4",
+    "format-message-parse": "^6.2.4",
+    "format-message-print": "^6.2.4"
   }
 }

--- a/packages/babel-plugin-transform-format-message/package.json
+++ b/packages/babel-plugin-transform-format-message/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-format-message",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "Pre-generate ids from default messages or inline a single language translation",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/babel-plugin-transform-format-message",
@@ -13,11 +13,11 @@
   "dependencies": {
     "@babel/helper-module-imports": "^7.0.0",
     "@babel/parser": "^7.0.0",
-    "format-message": "^6.2.3",
-    "format-message-estree-util": "^6.1.0",
-    "format-message-formats": "^6.2.0",
-    "format-message-generate-id": "^6.2.3",
-    "format-message-parse": "^6.2.3",
+    "format-message": "^6.2.4",
+    "format-message-estree-util": "^6.2.4",
+    "format-message-formats": "^6.2.4",
+    "format-message-generate-id": "^6.2.4",
+    "format-message-parse": "^6.2.4",
     "lookup-closest-locale": "^6.2.0",
     "source-map": "^0.5.7"
   }

--- a/packages/eslint-plugin-format-message/package.json
+++ b/packages/eslint-plugin-format-message/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-format-message",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "format-message i18n specific rules for ESLint",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/eslint-plugin-format-message",
@@ -23,10 +23,10 @@
     "icu"
   ],
   "dependencies": {
-    "format-message": "^6.2.3",
-    "format-message-estree-util": "^6.1.0",
-    "format-message-generate-id": "^6.2.3",
-    "format-message-parse": "^6.2.3",
+    "format-message": "^6.2.4",
+    "format-message-estree-util": "^6.2.4",
+    "format-message-generate-id": "^6.2.4",
+    "format-message-parse": "^6.2.4",
     "lookup-closest-locale": "^6.2.0"
   },
   "peerDependencies": {

--- a/packages/format-message-cli/package.json
+++ b/packages/format-message-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "format-message-cli",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "Command-line tools to lint, extract, and inline format-message translations",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/format-message-cli",
@@ -28,11 +28,11 @@
   },
   "dependencies": {
     "@babel/core": "^7.0.0",
-    "babel-plugin-extract-format-message": "^6.2.3",
-    "babel-plugin-transform-format-message": "^6.2.3",
+    "babel-plugin-extract-format-message": "^6.2.4",
+    "babel-plugin-transform-format-message": "^6.2.4",
     "commander": "^2.11.0",
     "eslint": "^6.0.1",
-    "eslint-plugin-format-message": "^6.2.3",
+    "eslint-plugin-format-message": "^6.2.4",
     "glob": "^5.0.15",
     "js-yaml": "^3.10.0",
     "mkdirp": "^0.5.1",

--- a/packages/format-message-estree-util/CHANGELOG.md
+++ b/packages/format-message-estree-util/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 6.2.4
+
+Update `MODULE_NAME_PATTERN` to enable more flexible imports.
+
+`MODULE_NAME_PATTERN` is used to determine which files in a project are using `format-message`. Until this point, we only looked for `format-message` as the last segment of the import specifier or require path, e.g. `require("../lib/format-message")` or `import _ from "@lib/i18n/format-message"`.
+
+Starting with v6.2.4, `MODULE_NAME_PATTERN` now finds virtually any import that ends in `format-message`. As long as the character that preceeds `format-message` is _not_ a letter, number, or underscore, the import will be recognized, e.g. `import "@lib.format-message"` or `require("lib/my-format-message")`.

--- a/packages/format-message-estree-util/package.json
+++ b/packages/format-message-estree-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "format-message-estree-util",
-  "version": "6.1.0",
+  "version": "6.2.4",
   "description": "Utility functions for format-message use in ECMAScript ASTs",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/format-message-estree-util",

--- a/packages/format-message-formats/package.json
+++ b/packages/format-message-formats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "format-message-formats",
-  "version": "6.2.0",
+  "version": "6.2.4",
   "description": "Options for Intl APIs used by format-message",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/format-message-formats",

--- a/packages/format-message-generate-id/package.json
+++ b/packages/format-message-generate-id/package.json
@@ -1,6 +1,6 @@
 {
   "name": "format-message-generate-id",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "Generate a message id from the default message pattern",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/format-message-generate-id",
@@ -12,7 +12,7 @@
   ],
   "dependencies": {
     "crc32": "^0.2.2",
-    "format-message-parse": "^6.2.3",
-    "format-message-print": "^6.2.3"
+    "format-message-parse": "^6.2.4",
+    "format-message-print": "^6.2.4"
   }
 }

--- a/packages/format-message-interpret/CHANGELOG.md
+++ b/packages/format-message-interpret/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.2.4
+
+Update specs to interpret signed zeroes properly.
+
 ## 6.2.0
 
 Add TypeScript type definitions.

--- a/packages/format-message-interpret/package.json
+++ b/packages/format-message-interpret/package.json
@@ -1,6 +1,6 @@
 {
   "name": "format-message-interpret",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "Convert format-message-parse ast to a function",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/format-message-interpret",
@@ -19,7 +19,7 @@
   ],
   "types": "types.d.ts",
   "dependencies": {
-    "format-message-formats": "^6.2.0",
+    "format-message-formats": "^6.2.4",
     "lookup-closest-locale": "^6.2.0"
   }
 }

--- a/packages/format-message-parse/package.json
+++ b/packages/format-message-parse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "format-message-parse",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "Parse ICU MessageFormat pattern strings to a compact ast",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/format-message-parse",

--- a/packages/format-message-print/package.json
+++ b/packages/format-message-print/package.json
@@ -1,6 +1,6 @@
 {
   "name": "format-message-print",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "Pretty print compact message format ast",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/format-message-print",

--- a/packages/format-message/package.json
+++ b/packages/format-message/package.json
@@ -1,6 +1,6 @@
 {
   "name": "format-message",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "Internationalize text, numbers, and dates using ICU Message Format",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message",
@@ -22,9 +22,9 @@
   ],
   "types": "types.d.ts",
   "dependencies": {
-    "format-message-formats": "^6.2.0",
-    "format-message-interpret": "^6.2.3",
-    "format-message-parse": "^6.2.3",
+    "format-message-formats": "^6.2.4",
+    "format-message-interpret": "^6.2.4",
+    "format-message-parse": "^6.2.4",
     "lookup-closest-locale": "^6.2.0"
   }
 }

--- a/packages/message-format/CHANGELOG.md
+++ b/packages/message-format/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.2.4
+
+Update the TypeScript type definition for `MessageFormat.supportedLocalesOf()` to communicate that it is a static method.
+
 ## 6.2.0
 
 Add TypeScript type definitions.

--- a/packages/message-format/package.json
+++ b/packages/message-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "message-format",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "Intl.MessageFormat prollyfill supporting ICU message format",
   "author": "Andy VanWagoner <andy@vanwago.net>",
   "homepage": "https://github.com/format-message/format-message/tree/master/packages/message-format",
@@ -23,7 +23,7 @@
   ],
   "types": "types.d.ts",
   "dependencies": {
-    "format-message-interpret": "^6.2.3",
-    "format-message-parse": "^6.2.3"
+    "format-message-interpret": "^6.2.4",
+    "format-message-parse": "^6.2.4"
   }
 }


### PR DESCRIPTION
This release contains changes from the following commits:

* `2022-02-16`: #323
* `2022-02-16`: #325
* `2020-03-18`: #312
* `2020-03-18`: #311
* `2020-03-05`: #310
* `2020-03-04`: #309
* `2020-02-24`: #308
* `2020-02-06`: #307
* `2020-01-27`: #305
* `2020-01-27`: #304
* `2020-01-06`: #301
* `2019-12-31`: #300
* `2019-12-31`: #299
* `2019-12-13`: #298
* `2019-12-03`: #297
* `2019-11-12`: #295
* `2019-10-31`: #294
* `2019-10-22`: #293
* `2019-10-02`: #291
* `2019-09-21`: #290
* `2019-09-21`: #289
* `2019-09-21`: [chore(benchmark): fix benchmark](https://github.com/format-message/format-message/commit/13b7c34393ae0093e14a9b70644d36e67a7ebe64)
* `2019-09-21`: #287
* `2019-09-21`: #288
* `2019-08-24`: #285
* `2019-08-14`: #282
* `2019-08-06`: #280
* `2019-07-29`: #279
* `2019-07-29`: #277
* `2019-07-29`: #278
* `2019-07-18`: #276
* `2019-07-16`: #274
* `2019-07-16`: #273
* `2019-07-15`: #272